### PR TITLE
Fix bug in example on README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -158,7 +158,7 @@ expressions and store variables:
 
         @_('NUMBER')
         def expr(self, p):
-            return p.NUMBER
+            return int(p.NUMBER)
 
         @_('NAME')
         def expr(self, p):


### PR DESCRIPTION
 Fix example to match example in calc.py; NUMBER was not returned as int in README