### PR TITLE
Require python >= 3.6 in setup.py and include tests with release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include example *
 recursive-include docs *
+recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,14 @@ SLY is an implementation of lex and yacc for Python 3.
             maintainer_email = "dave@dabeaz.com",
             url = "https://github.com/dabeaz/sly",
             packages = ['sly'],
+            python_requires = ">=3.6",
             tests_require = tests_require,
             extras_require = {
                 'test': tests_require,
               },
             classifiers = [
-              'Programming Language :: Python :: 3',
+                'Programming Language :: Python :: 3',
+                'Programming Language :: Python :: 3.6',
+                'Programming Language :: Python :: 3.7',
               ]
             )


### PR DESCRIPTION
`setup.py` now requires that it is installed on python 3.6 or greater.

Also wanted to include sly in the [nix package manager](https://github.com/NixOS/nixpkgs) one thing we try to do is include tests with each package so that it is easy to test.