### PR TITLE
Fix column computation in documentation

### DIFF
--- a/docs/sly.rst
+++ b/docs/sly.rst
@@ -305,9 +305,7 @@ backwards until you reach the previous newline::
     #     token is a token instance
     def find_column(text, token):
         last_cr = text.rfind('\n', 0, token.index)
-        if last_cr < 0:
-            last_cr = 0
-        column = (token.index - last_cr) + 1
+        column = token.index - last_cr
         return column
 
 Since column information is often only useful in the context of error

--- a/docs/sly.rst
+++ b/docs/sly.rst
@@ -301,7 +301,7 @@ column information as a separate step.  For instance, you can search
 backwards until you reach the previous newline::
 
     # Compute column.
-    #     input is the input text string
+    #     text is the input text string
     #     token is a token instance
     def find_column(text, token):
         last_cr = text.rfind('\n', 0, token.index)


### PR DESCRIPTION
The column computation function in the documentation had a few problems:

1. Comment spoke about `input` parameter, but it's actually `text`.
2. Something off-by-one must be happening, as `last_cr` ends up at the newline character, except at the first line.

With respect to the second item, I hacked a quick test (attached), which also incudes the fixed version.

I tried to make the function as small as possible so I deleted the `if` statement, so the function now relies on `rfind` returning `-1` if it failed to find a new-line. Not sure if you like that, however it is documented functionality: https://docs.python.org/3/library/stdtypes.html?highlight=str%20rfind#str.rfind  so should be quite stable behaviour.


[t.py.txt](https://github.com/dabeaz/sly/files/4146935/t.py.txt)
