### PR TITLE
Update date for talk in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ Further documentation can be found at `https://sly.readthedocs.io/en/latest <htt
 Talks
 -----
 
-* `Reinventing the Parser Generator <https://www.youtube.com/watch?v=zJ9z6Ge-vXs>`_, talk by David Beazley at PyCon 2017, Cleveland.
+* `Reinventing the Parser Generator <https://www.youtube.com/watch?v=zJ9z6Ge-vXs>`_, talk by David Beazley at PyCon 2018, Cleveland.
 
 Resources
 ---------


### PR DESCRIPTION
The date for the Reinventing the Parser Generator talk was 2018 according to the YouTube title.