### PR TITLE
Add IGNORECASE ability to Token Remapping.

### DIFF
--- a/sly/lex.py
+++ b/sly/lex.py
@@ -277,6 +277,8 @@ class Lexer(metaclass=LexerMeta):
         for (key, val), newtok in cls._remap.items():
             if key not in cls._remapping:
                 cls._remapping[key] = {}
+            if cls.reflags & re.IGNORECASE:
+                 val = val.lower()
             cls._remapping[key][val] = newtok
 
         remapped_toks = set()
@@ -411,7 +413,11 @@ class Lexer(metaclass=LexerMeta):
                     tok.type = m.lastgroup
 
                     if tok.type in _remapping:
-                        tok.type = _remapping[tok.type].get(tok.value, tok.type)
+                        if self.reflags & re.IGNORECASE:
+                            token_search = tok.value.lower()
+                        else:
+                            token_search = tok.value
+                        tok.type = _remapping[tok.type].get(token_search, tok.type)
 
                     if tok.type in _token_funcs:
                         self.index = index


### PR DESCRIPTION
With reference to:
https://github.com/dabeaz/sly/issues/62
I've found a problem with tokens remapping in the eventuality of:
reflags = re.IGNORECASE
This change allows creating special cases ignoring capitalization in the eventuality of
reflags = re.IGNORECASE assignment in Lexer class.

Example:
class MyLexer(sly.Lexer):
    reflags = re.IGNORECASE
    # Base ID rule
    ID = r'[a-zA-Z_][a-zA-Z0-9_]*'

    # Special cases
    ID['if'] = IF
    ID['else'] = ELSE
    ID['while'] = WHILE
    # Now if,If,IF,iF are handle as the same special cases